### PR TITLE
Fix broken build due to an old LIBIGL diag.h dependency

### DIFF
--- a/include/SaddlePoint/DiagonalDamping.h
+++ b/include/SaddlePoint/DiagonalDamping.h
@@ -7,7 +7,6 @@
 // obtain one at http://mozilla.org/MPL/2.0/.
 #ifndef SADDLEPOINT_DIAGONAL_DAMPING_H
 #define SADDLEPOINT_DIAGONAL_DAMPING_H
-#include <igl/diag.h>
 #include <Eigen/Core>
 #include <Eigen/Sparse>
 #include <string>


### PR DESCRIPTION
diag.h was removed long time ago from LIBIGL